### PR TITLE
Bar 77 run experiments with no gwas all 800 k sn ps for lasso net and mb smth else

### DIFF
--- a/src/local/configs/default.yaml
+++ b/src/local/configs/default.yaml
@@ -1,3 +1,8 @@
+defaults:
+  - model: lassonet
+  - experiment: all_snps 
+  - _self_ 
+
 split_dir: /gpfs/gpfs0/ukb_data/test/uneven_split
 node_index: 0
 gwas_node_index: node_index
@@ -27,16 +32,4 @@ data:
     val: ${.root}_val.tsv
     test: ${.root}_test.tsv
   gwas: ${split_dir}/gwas/${phenotype.name}/node_${node_index}/fold_${fold_index}.gwas.tsv
-  
 
-model:
-  name: ???
-  params: {}
-    
-experiment:
-  name: local-models
-  include_genotype: True
-  include_covariates: True
-  different_node_gwas: False
-  snp_count: 1000
-  random_state: 0

--- a/src/local/configs/experiment/all_snps.yaml
+++ b/src/local/configs/experiment/all_snps.yaml
@@ -1,0 +1,7 @@
+name: local-models-all-snps
+include_genotype: True
+include_covariates: True
+different_node_gwas: False
+snp_count: 596409
+random_state: 0
+test_samples_limit: 1000

--- a/src/local/configs/experiment/local.yaml
+++ b/src/local/configs/experiment/local.yaml
@@ -1,0 +1,6 @@
+name: local-models
+include_genotype: True
+include_covariates: True
+different_node_gwas: False
+snp_count: 1000
+random_state: 0

--- a/src/local/configs/model/lassonet.yaml
+++ b/src/local/configs/model/lassonet.yaml
@@ -3,23 +3,22 @@
 model:
   name: lassonet
   precision: 32
-  batch_size: 512
-  max_epochs: 64
+  batch_size: 128
+  max_epochs: 96
   hidden_size: 512
-  alpha_start: -3
-  alpha_end: -1
-  init_limit: 0.01
-  patience: 10
+  alpha_start: -1
+  alpha_end: 0.5
+  init_limit: 0.002
+  patience: 36
   
 experiment:
   gpus: 1
   optimizer:
-    name: adamw
-    lr: 1e-3
-    weight_decay: 1e-2
+    name: sgd
+    lr: 5e-3
+    weight_decay: 0.0
   scheduler:
-    name: one_cycle_lr
+    name: exponential_lr
     rounds: ${model.max_epochs}
     epochs_in_round: 1
-    div_factor: 25
-    final_div_factor: 1e+5
+    gamma: 0.97

--- a/src/local/experiment.py
+++ b/src/local/experiment.py
@@ -16,6 +16,7 @@ from fl.datasets.memory import load_covariates, load_phenotype, load_from_pgen, 
 from nn.lightning import DataModule
 from nn.train import prepare_trainer
 from nn.models import MLPRegressor, LassoNetRegressor
+from utils.phenotype import MEAN_PHENO_DICT
 
 
 class LocalExperiment():
@@ -56,9 +57,9 @@ class LocalExperiment():
     def load_data(self):
         self.logger.info("Loading data")
         
-        self.y_train = load_phenotype(self.cfg.data.phenotype.train) - 160
-        self.y_val = load_phenotype(self.cfg.data.phenotype.val) - 160
-        self.y_test = load_phenotype(self.cfg.data.phenotype.test) - 160
+        self.y_train = load_phenotype(self.cfg.data.phenotype.train) - MEAN_PHENO_DICT[self.cfg.phenotype.name]
+        self.y_val = load_phenotype(self.cfg.data.phenotype.val) - MEAN_PHENO_DICT[self.cfg.phenotype.name]
+        self.y_test = load_phenotype(self.cfg.data.phenotype.test) - MEAN_PHENO_DICT[self.cfg.phenotype.name]
         test_samples_limit = self.cfg.experiment.get('test_samples_limit', None)
         self.y_test = self.y_test[:test_samples_limit]
 

--- a/src/local/wrapper.sh
+++ b/src/local/wrapper.sh
@@ -3,7 +3,7 @@
 #SBATCH --partition $PARTITION_TYPE # one of gpu, gpu_devel
 #SBATCH --nodes 1 # amount of nodes allocated 
 #SBATCH --time 6:00:00 # hh:mm:ss, walltime 
-#SBATCH --mem $MEM 
+##SBATCH --mem $MEM 
 #SBATCH --cpus-per-task 1
 #SBATCH --export ALL
 #gpu_placeholder
@@ -13,8 +13,6 @@ source /trinity/home/$USER/.mlflow/credentials
 set +o allexport
 
 cd /trinity/home/$USER/uk-biobank/src
-# remove old parent run id because sometimes clients start faster than server and use old parent run id
-rm .mlflow_parent_run_id
 
 singularity exec --nv -B /gpfs/gpfs0/ukb_data,/gpfs/gpfs0/$USER \
-  ../image.sif /trinity/home/$USER/.conda/envs/fl/bin/python -u -m local.experiment 
+  ../image.sif /trinity/home/$USER/.conda/envs/fl/bin/python -u -m local.experiment "$@"

--- a/src/nn/lightning.py
+++ b/src/nn/lightning.py
@@ -1,35 +1,33 @@
 from typing import List
 import numpy
 from pytorch_lightning import LightningDataModule
-import torch
 from torch.utils.data import TensorDataset, DataLoader
+
+from .memory import Int8Dataset
 
 
 class DataModule(LightningDataModule):
     def __init__(self, X_train: numpy.ndarray, X_val: numpy.ndarray, X_test: numpy.ndarray, y_train: numpy.ndarray, y_val: numpy.ndarray, y_test: numpy.ndarray, batch_size: int):
         super().__init__()
-        self._X_train = torch.tensor(X_train, dtype=torch.float32)
-        self._X_val = torch.tensor(X_val, dtype=torch.float32)
-        self._X_test = torch.tensor(X_test, dtype=torch.float32)
-        self.train_dataset = TensorDataset(self._X_train, torch.tensor(y_train, dtype=torch.float32))
-        self.val_dataset = TensorDataset(self._X_val, torch.tensor(y_val, dtype=torch.float32))
-        self.test_dataset = TensorDataset(self._X_test, torch.tensor(y_test, dtype=torch.float32))
+        self.train_dataset = Int8Dataset(X_train, y_train)
+        self.val_dataset = Int8Dataset(X_val, y_val)
+        self.test_dataset = Int8Dataset(X_test, y_test)
         self.batch_size = batch_size
 
     def train_dataloader(self) -> DataLoader:
-        loader = DataLoader(self.train_dataset, batch_size=self.batch_size, shuffle=True, num_workers=1)
+        loader = DataLoader(self.train_dataset, batch_size=self.batch_size, shuffle=True, num_workers=1, prefetch_factor=1)
         return loader
     
     def val_dataloader(self) -> DataLoader:
-        loader = DataLoader(self.val_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1)
+        loader = DataLoader(self.val_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1, prefetch_factor=1)
         return loader
     
     def test_dataloader(self) -> DataLoader:
-        loader = DataLoader(self.test_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1)
+        loader = DataLoader(self.test_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1, prefetch_factor=1)
         return loader
 
     def predict_dataloader(self) -> List[DataLoader]:
-        train_loader = DataLoader(self.train_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1)
+        train_loader = DataLoader(self.train_dataset, batch_size=self.batch_size, shuffle=False, num_workers=1, prefetch_factor=1)
         val_loader = self.val_dataloader()
         test_loader = self.test_dataloader()
         return [train_loader, val_loader, test_loader]
@@ -47,4 +45,4 @@ class DataModule(LightningDataModule):
         return len(self.test_dataset)
 
     def feature_count(self):
-        return self._X_train.shape[1]
+        return self.train_dataset.feature_count()

--- a/src/nn/memory.py
+++ b/src/nn/memory.py
@@ -1,0 +1,17 @@
+import numpy
+from typing import Tuple
+
+
+class Int8Dataset:
+    def __init__(self, X: numpy.ndarray, y: numpy.ndarray) -> None:
+        self.X = X
+        self.y = y
+
+    def __len__(self) -> int:
+        return self.X.shape[0]
+
+    def __getitem__(self, idx: int) -> Tuple[numpy.ndarray, numpy.ndarray]:
+        return self.X[idx, :].astype(numpy.float32), self.y[idx]
+    
+    def feature_count(self) -> int:
+        return self.X.shape[1]

--- a/src/nn/models.py
+++ b/src/nn/models.py
@@ -214,8 +214,6 @@ class LassoNetRegressor(BaseNet):
         return out 
 
     def calculate_loss(self, y_hat: torch.Tensor, y: torch.Tensor) -> torch.Tensor:
-        # print(f'SHAPES IN LOSS')
-        # print(y.shape)
         y = y.unsqueeze(1).tile(dims=(1, self.hidden_size))
         # print(y.shape, y_hat.shape)
         return mse_loss(y_hat, y)

--- a/src/utils/phenotype.py
+++ b/src/utils/phenotype.py
@@ -1,0 +1,1 @@
+MEAN_PHENO_DICT = {'standing_height': 160}


### PR DESCRIPTION
1. Changed LassoNET alpha regularization parameter range
2. Added pretraining for covariates coefficients
3. Memory-efficient numpy dataset for genotype data
4. Config option to limit test samples number for saving memory