### PR TITLE
[BAR-142] RF performance old new model on modified new data

### DIFF
--- a/src/JupyterNotebooks/compare_rf.ipynb
+++ b/src/JupyterNotebooks/compare_rf.ipynb
@@ -2,38 +2,100 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "import pandas as pd"
-   ],
+   "execution_count": 1,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Import new data"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Import new data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 2,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "       IID ancestry\n0  HG00144      GBR\n1  HG00264      GBR\n2  HG00237      GBR\n3  HG00410      CHS\n4  HG00097      GBR",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>ancestry</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>HG00144</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>HG00264</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>HG00237</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>HG00410</td>\n      <td>CHS</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>HG00097</td>\n      <td>GBR</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IID</th>\n",
+       "      <th>ancestry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>HG00144</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>HG00264</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>HG00237</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>HG00410</td>\n",
+       "      <td>CHS</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>HG00097</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       IID ancestry\n",
+       "0  HG00144      GBR\n",
+       "1  HG00264      GBR\n",
+       "2  HG00237      GBR\n",
+       "3  HG00410      CHS\n",
+       "4  HG00097      GBR"
+      ]
      },
      "execution_count": 2,
      "metadata": {},
@@ -46,50 +108,106 @@
     "new_val = pd.read_table('/media/storage/TG/data_compare/new_data/y/fold_0_val.tsv')\n",
     "new = pd.concat([new_val, new_test, new_train])\n",
     "new.head()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 3,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "new_test_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_test_projections.csv.eigenvec.sscore')\n",
     "new_train_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_train_projections.csv.eigenvec.sscore')\n",
     "new_val_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_val_projections.csv.eigenvec.sscore')"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Import old data"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Import old data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 4,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "       IID  pop\n0  HG00096  GBR\n1  HG00097  GBR\n2  HG00099  GBR\n3  HG00100  GBR\n4  HG00101  GBR",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>HG00096</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>HG00097</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>HG00099</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>HG00100</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>HG00101</td>\n      <td>GBR</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IID</th>\n",
+       "      <th>pop</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>HG00096</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>HG00097</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>HG00099</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>HG00100</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>HG00101</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       IID  pop\n",
+       "0  HG00096  GBR\n",
+       "1  HG00097  GBR\n",
+       "2  HG00099  GBR\n",
+       "3  HG00100  GBR\n",
+       "4  HG00101  GBR"
+      ]
      },
      "execution_count": 4,
      "metadata": {},
@@ -99,35 +217,35 @@
    "source": [
     "old = pd.read_csv('/media/storage/TG/data_compare/old_data/y/y_all.csv')\n",
     "old.head()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Merge old and new"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Merge old and new"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 5,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "1415"
+      "text/plain": [
+       "1415"
+      ]
      },
-     "execution_count": 13,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -137,34 +255,64 @@
     "all.head()\n",
     "samples = list(all['IID'].values)\n",
     "len(samples)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Compare new and old ancestry"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Compare new and old ancestry"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 6,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "Empty DataFrame\nColumns: [IID, pop, ancestry]\nIndex: []",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n      <th>ancestry</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IID</th>\n",
+       "      <th>pop</th>\n",
+       "      <th>ancestry</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "Empty DataFrame\n",
+       "Columns: [IID, pop, ancestry]\n",
+       "Index: []"
+      ]
      },
      "execution_count": 6,
      "metadata": {},
@@ -174,34 +322,199 @@
    "source": [
     "err_samples = all[all['pop'] != all['ancestry']]\n",
     "err_samples.head()"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Samples that are present in old_data, but not in new_data"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Samples that are present in old_data, but not in new_data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 7,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [
     {
      "data": {
-      "text/plain": "          IID  pop\n39    HG00142  GBR\n48    HG00155  GBR\n407   HG02067  KHV\n496   HG02681  PJL\n657   HG03351  ESN\n667   HG03382  MSL\n671   HG03394  MSL\n686   HG03451  MSL\n756   HG03673  STU\n771   HG03696  STU\n881   HG03998  STU\n924   HG04210  STU\n939   NA18511  YRI\n1155  NA19027  LWK\n1215  NA19129  YRI\n1227  NA19153  YRI\n1253  NA19238  YRI\n1282  NA19355  LWK\n1285  NA19374  LWK\n1291  NA19380  LWK\n1297  NA19397  LWK\n1310  NA19443  LWK\n1408  NA20792  TSI",
-      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>39</th>\n      <td>HG00142</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>48</th>\n      <td>HG00155</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>407</th>\n      <td>HG02067</td>\n      <td>KHV</td>\n    </tr>\n    <tr>\n      <th>496</th>\n      <td>HG02681</td>\n      <td>PJL</td>\n    </tr>\n    <tr>\n      <th>657</th>\n      <td>HG03351</td>\n      <td>ESN</td>\n    </tr>\n    <tr>\n      <th>667</th>\n      <td>HG03382</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>671</th>\n      <td>HG03394</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>686</th>\n      <td>HG03451</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>756</th>\n      <td>HG03673</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>771</th>\n      <td>HG03696</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>881</th>\n      <td>HG03998</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>924</th>\n      <td>HG04210</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>939</th>\n      <td>NA18511</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1155</th>\n      <td>NA19027</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1215</th>\n      <td>NA19129</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1227</th>\n      <td>NA19153</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1253</th>\n      <td>NA19238</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1282</th>\n      <td>NA19355</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1285</th>\n      <td>NA19374</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1291</th>\n      <td>NA19380</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1297</th>\n      <td>NA19397</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1310</th>\n      <td>NA19443</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1408</th>\n      <td>NA20792</td>\n      <td>TSI</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>IID</th>\n",
+       "      <th>pop</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>39</th>\n",
+       "      <td>HG00142</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>48</th>\n",
+       "      <td>HG00155</td>\n",
+       "      <td>GBR</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>407</th>\n",
+       "      <td>HG02067</td>\n",
+       "      <td>KHV</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>496</th>\n",
+       "      <td>HG02681</td>\n",
+       "      <td>PJL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>657</th>\n",
+       "      <td>HG03351</td>\n",
+       "      <td>ESN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>667</th>\n",
+       "      <td>HG03382</td>\n",
+       "      <td>MSL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>671</th>\n",
+       "      <td>HG03394</td>\n",
+       "      <td>MSL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>686</th>\n",
+       "      <td>HG03451</td>\n",
+       "      <td>MSL</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>756</th>\n",
+       "      <td>HG03673</td>\n",
+       "      <td>STU</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>771</th>\n",
+       "      <td>HG03696</td>\n",
+       "      <td>STU</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>881</th>\n",
+       "      <td>HG03998</td>\n",
+       "      <td>STU</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>924</th>\n",
+       "      <td>HG04210</td>\n",
+       "      <td>STU</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>939</th>\n",
+       "      <td>NA18511</td>\n",
+       "      <td>YRI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1155</th>\n",
+       "      <td>NA19027</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1215</th>\n",
+       "      <td>NA19129</td>\n",
+       "      <td>YRI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1227</th>\n",
+       "      <td>NA19153</td>\n",
+       "      <td>YRI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1253</th>\n",
+       "      <td>NA19238</td>\n",
+       "      <td>YRI</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1282</th>\n",
+       "      <td>NA19355</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1285</th>\n",
+       "      <td>NA19374</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1291</th>\n",
+       "      <td>NA19380</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1297</th>\n",
+       "      <td>NA19397</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1310</th>\n",
+       "      <td>NA19443</td>\n",
+       "      <td>LWK</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1408</th>\n",
+       "      <td>NA20792</td>\n",
+       "      <td>TSI</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "          IID  pop\n",
+       "39    HG00142  GBR\n",
+       "48    HG00155  GBR\n",
+       "407   HG02067  KHV\n",
+       "496   HG02681  PJL\n",
+       "657   HG03351  ESN\n",
+       "667   HG03382  MSL\n",
+       "671   HG03394  MSL\n",
+       "686   HG03451  MSL\n",
+       "756   HG03673  STU\n",
+       "771   HG03696  STU\n",
+       "881   HG03998  STU\n",
+       "924   HG04210  STU\n",
+       "939   NA18511  YRI\n",
+       "1155  NA19027  LWK\n",
+       "1215  NA19129  YRI\n",
+       "1227  NA19153  YRI\n",
+       "1253  NA19238  YRI\n",
+       "1282  NA19355  LWK\n",
+       "1285  NA19374  LWK\n",
+       "1291  NA19380  LWK\n",
+       "1297  NA19397  LWK\n",
+       "1310  NA19443  LWK\n",
+       "1408  NA20792  TSI"
+      ]
      },
      "execution_count": 7,
      "metadata": {},
@@ -212,48 +525,52 @@
     "new.rename(columns = {'ancestry':'pop'}, inplace = True)\n",
     "diff = old.merge(new, how = 'outer' ,indicator=True).loc[lambda x : x['_merge']=='left_only']\n",
     "diff[['IID', 'pop']]"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Save filtered new_data"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Save filtered new_data"
+   ]
   },
   {
    "cell_type": "code",
    "execution_count": 9,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "save = new_test[new_test['IID'].isin(samples)]\n",
     "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_test.tsv', sep='\\t', index=False)\n",
-    "save = new_train[new_train['#IID'].isin(samples)]\n",
+    "save = new_train[new_train['IID'].isin(samples)]\n",
     "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_train.tsv', sep='\\t', index=False)\n",
     "save = new_val[new_val['IID'].isin(samples)]\n",
     "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_val.tsv', sep='\\t', index=False)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
+   "metadata": {
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   },
    "outputs": [],
    "source": [
     "save = new_test_x[new_test_x['#IID'].isin(samples)]\n",
@@ -262,60 +579,100 @@
     "save.to_csv('/media/storage/TG/data_compare/new_data/x_filtered/fold_0_train_projections.csv.eigenvec.sscore', sep='\\t', index=False)\n",
     "save = new_val_x[new_val_x['#IID'].isin(samples)]\n",
     "save.to_csv('/media/storage/TG/data_compare/new_data/x_filtered/fold_0_val_projections.csv.eigenvec.sscore', sep='\\t', index=False)"
-   ],
-   "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
-   }
+   ]
   },
   {
    "cell_type": "markdown",
-   "source": [
-    "## Run experiment"
-   ],
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%% md\n"
     }
-   }
+   },
+   "source": [
+    "## Run experiment with cross validation"
+   ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
-   "outputs": [],
-   "source": [
-    "!python ../local/experiment.py\n"
-   ],
+   "execution_count": 29,
    "metadata": {
-    "collapsed": false,
     "pycharm": {
      "name": "#%%\n"
     }
-   }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "/home/genxadmin/test_ukb/src/local\n",
+      "/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/xgboost/compat.py:36: FutureWarning: pandas.Int64Index is deprecated and will be removed from pandas in a future version. Use pandas.Index with the appropriate dtype instead.\n",
+      "  from pandas import MultiIndex, Int64Index\n",
+      "{'study': 'tg', 'split_dir': '/media/storage/TG/data_compare', 'node': 'ALL', 'fold_index': 0, 'phenotype': {'name': 'ancestry'}, 'data': {'genotype': {'root': '/media/storage/TG/data/chip/superpop_split/genotypes/${node}/fold_${fold_index}', 'train': '${.root}_train', 'val': '${.root}_val', 'test': '${.root}_test'}, 'x_reduced': {'root': '${split_dir}/new_data/x_filtered/fold_${fold_index}', 'train': '${.root}_train_projections.csv.eigenvec.sscore', 'val': '${.root}_val_projections.csv.eigenvec.sscore', 'test': '${.root}_test_projections.csv.eigenvec.sscore'}, 'phenotype': {'name': 'ancestry', 'root': '${split_dir}/new_data/y_filtered/fold_${fold_index}', 'train': '${.root}_train.tsv', 'val': '${.root}_val.tsv', 'test': '${.root}_test.tsv'}}, 'model': {'name': 'random_forest', 'params': {'max_depth': None, 'min_samples_leaf': 1, 'n_estimators': 100}}, 'experiment': {'name': 'local-models-tg', 'include_genotype': True, 'include_covariates': False, 'random_state': 0, 'test_samples_limit': None, 'gpus': 0}}\n",
+      "dict_keys(['mlp_classifier', 'random_forest'])\n",
+      "[2022-08-01 10:30:04,156][root][INFO] - Loading data\n",
+      "[2022-08-01 10:30:04,168][root][INFO] - Loading sample indices\n",
+      "[2022-08-01 10:30:04,216][root][INFO] - 20 features loaded\n",
+      "2022/08/01 10:30:04 INFO mlflow.tracking.fluent: Experiment with name 'local-models-tg' does not exist. Creating a new experiment.\n",
+      "[2022-08-01 10:30:04,292][root][INFO] - Training\n",
+      "{'fit_time': array([0.34803534, 0.34181333, 0.33814836, 0.34395027, 0.33951092,\n",
+      "       0.34043574, 0.34205604, 0.35287786, 0.33985043, 0.34079313]), 'score_time': array([0.011096  , 0.01089907, 0.01042247, 0.01063991, 0.01041722,\n",
+      "       0.01075578, 0.0106082 , 0.01030874, 0.01069617, 0.01088381]), 'test_score': array([0.97887324, 0.97183099, 0.98591549, 0.98591549, 0.97887324,\n",
+      "       1.        , 0.9929078 , 0.9858156 , 0.9929078 , 1.        ]), 'train_score': array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])}\n",
+      "Error in atexit._run_exitfuncs:\n",
+      "Traceback (most recent call last):\n",
+      "  File \"/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/mlflow/tracking/fluent.py\", line 371, in end_run\n",
+      "    MlflowClient().set_terminated(run.info.run_id, status)\n",
+      "  File \"/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/mlflow/tracking/client.py\", line 1466, in set_terminated\n",
+      "    self._tracking_client.set_terminated(run_id, status, end_time)\n",
+      "  File \"/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/mlflow/tracking/_tracking_service/client.py\", line 411, in set_terminated\n",
+      "    self.store.update_run_info(\n",
+      "  File \"/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/mlflow/store/tracking/file_store.py\", line 477, in update_run_info\n",
+      "    run_info = self._get_run_info(run_id)\n",
+      "  File \"/home/genxadmin/miniconda3/envs/uk/lib/python3.9/site-packages/mlflow/store/tracking/file_store.py\", line 549, in _get_run_info\n",
+      "    raise MlflowException(\n",
+      "mlflow.exceptions.MlflowException: Run '3947529b48d8476480c548aa16380360' not found\n",
+      "/home/genxadmin/test_ukb/src/JupyterNotebooks\n"
+     ]
+    }
+   ],
+   "source": [
+    "%cd ../local\n",
+    "!python experiment.py\n",
+    "%cd ../JupyterNotebooks"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Results\n",
+    "```\n",
+    "'test_score': array([0.97887324, 0.97183099, 0.98591549, 0.98591549, 0.97887324, 1., 0.9929078, 0.9858156, 0.9929078, 1.]),\n",
+    "'train_score': array([1., 1., 1., 1., 1., 1., 1., 1., 1., 1.])}\n",
+    "```"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
    "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
     "name": "ipython",
-    "version": 2
+    "version": 3
    },
    "file_extension": ".py",
    "mimetype": "text/x-python",
    "name": "python",
    "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "pygments_lexer": "ipython3",
+   "version": "3.9.7"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/src/JupyterNotebooks/compare_rf.ipynb
+++ b/src/JupyterNotebooks/compare_rf.ipynb
@@ -1,0 +1,321 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "import pandas as pd"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Import new data"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "       IID ancestry\n0  HG00144      GBR\n1  HG00264      GBR\n2  HG00237      GBR\n3  HG00410      CHS\n4  HG00097      GBR",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>ancestry</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>HG00144</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>HG00264</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>HG00237</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>HG00410</td>\n      <td>CHS</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>HG00097</td>\n      <td>GBR</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new_test = pd.read_table('/media/storage/TG/data_compare/new_data/y/fold_0_test.tsv')\n",
+    "new_train = pd.read_table('/media/storage/TG/data_compare/new_data/y/fold_0_train.tsv')\n",
+    "new_val = pd.read_table('/media/storage/TG/data_compare/new_data/y/fold_0_val.tsv')\n",
+    "new = pd.concat([new_val, new_test, new_train])\n",
+    "new.head()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "outputs": [],
+   "source": [
+    "new_test_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_test_projections.csv.eigenvec.sscore')\n",
+    "new_train_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_train_projections.csv.eigenvec.sscore')\n",
+    "new_val_x = pd.read_table('/media/storage/TG/data_compare/new_data/x/fold_0_val_projections.csv.eigenvec.sscore')"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Import old data"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "       IID  pop\n0  HG00096  GBR\n1  HG00097  GBR\n2  HG00099  GBR\n3  HG00100  GBR\n4  HG00101  GBR",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>0</th>\n      <td>HG00096</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>1</th>\n      <td>HG00097</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>2</th>\n      <td>HG00099</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>3</th>\n      <td>HG00100</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>4</th>\n      <td>HG00101</td>\n      <td>GBR</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "old = pd.read_csv('/media/storage/TG/data_compare/old_data/y/y_all.csv')\n",
+    "old.head()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Merge old and new"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "1415"
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "all = pd.merge(old, new)\n",
+    "all.head()\n",
+    "samples = list(all['IID'].values)\n",
+    "len(samples)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Compare new and old ancestry"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "Empty DataFrame\nColumns: [IID, pop, ancestry]\nIndex: []",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n      <th>ancestry</th>\n    </tr>\n  </thead>\n  <tbody>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 6,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "err_samples = all[all['pop'] != all['ancestry']]\n",
+    "err_samples.head()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Samples that are present in old_data, but not in new_data"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "outputs": [
+    {
+     "data": {
+      "text/plain": "          IID  pop\n39    HG00142  GBR\n48    HG00155  GBR\n407   HG02067  KHV\n496   HG02681  PJL\n657   HG03351  ESN\n667   HG03382  MSL\n671   HG03394  MSL\n686   HG03451  MSL\n756   HG03673  STU\n771   HG03696  STU\n881   HG03998  STU\n924   HG04210  STU\n939   NA18511  YRI\n1155  NA19027  LWK\n1215  NA19129  YRI\n1227  NA19153  YRI\n1253  NA19238  YRI\n1282  NA19355  LWK\n1285  NA19374  LWK\n1291  NA19380  LWK\n1297  NA19397  LWK\n1310  NA19443  LWK\n1408  NA20792  TSI",
+      "text/html": "<div>\n<style scoped>\n    .dataframe tbody tr th:only-of-type {\n        vertical-align: middle;\n    }\n\n    .dataframe tbody tr th {\n        vertical-align: top;\n    }\n\n    .dataframe thead th {\n        text-align: right;\n    }\n</style>\n<table border=\"1\" class=\"dataframe\">\n  <thead>\n    <tr style=\"text-align: right;\">\n      <th></th>\n      <th>IID</th>\n      <th>pop</th>\n    </tr>\n  </thead>\n  <tbody>\n    <tr>\n      <th>39</th>\n      <td>HG00142</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>48</th>\n      <td>HG00155</td>\n      <td>GBR</td>\n    </tr>\n    <tr>\n      <th>407</th>\n      <td>HG02067</td>\n      <td>KHV</td>\n    </tr>\n    <tr>\n      <th>496</th>\n      <td>HG02681</td>\n      <td>PJL</td>\n    </tr>\n    <tr>\n      <th>657</th>\n      <td>HG03351</td>\n      <td>ESN</td>\n    </tr>\n    <tr>\n      <th>667</th>\n      <td>HG03382</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>671</th>\n      <td>HG03394</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>686</th>\n      <td>HG03451</td>\n      <td>MSL</td>\n    </tr>\n    <tr>\n      <th>756</th>\n      <td>HG03673</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>771</th>\n      <td>HG03696</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>881</th>\n      <td>HG03998</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>924</th>\n      <td>HG04210</td>\n      <td>STU</td>\n    </tr>\n    <tr>\n      <th>939</th>\n      <td>NA18511</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1155</th>\n      <td>NA19027</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1215</th>\n      <td>NA19129</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1227</th>\n      <td>NA19153</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1253</th>\n      <td>NA19238</td>\n      <td>YRI</td>\n    </tr>\n    <tr>\n      <th>1282</th>\n      <td>NA19355</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1285</th>\n      <td>NA19374</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1291</th>\n      <td>NA19380</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1297</th>\n      <td>NA19397</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1310</th>\n      <td>NA19443</td>\n      <td>LWK</td>\n    </tr>\n    <tr>\n      <th>1408</th>\n      <td>NA20792</td>\n      <td>TSI</td>\n    </tr>\n  </tbody>\n</table>\n</div>"
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "new.rename(columns = {'ancestry':'pop'}, inplace = True)\n",
+    "diff = old.merge(new, how = 'outer' ,indicator=True).loc[lambda x : x['_merge']=='left_only']\n",
+    "diff[['IID', 'pop']]"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Save filtered new_data"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "outputs": [],
+   "source": [
+    "save = new_test[new_test['IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_test.tsv', sep='\\t', index=False)\n",
+    "save = new_train[new_train['#IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_train.tsv', sep='\\t', index=False)\n",
+    "save = new_val[new_val['IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/y_filtered/fold_0_val.tsv', sep='\\t', index=False)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "outputs": [],
+   "source": [
+    "save = new_test_x[new_test_x['#IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/x_filtered/fold_0_test_projections.csv.eigenvec.sscore', sep='\\t', index=False)\n",
+    "save = new_train_x[new_train_x['#IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/x_filtered/fold_0_train_projections.csv.eigenvec.sscore', sep='\\t', index=False)\n",
+    "save = new_val_x[new_val_x['#IID'].isin(samples)]\n",
+    "save.to_csv('/media/storage/TG/data_compare/new_data/x_filtered/fold_0_val_projections.csv.eigenvec.sscore', sep='\\t', index=False)"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
+   "source": [
+    "## Run experiment"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%% md\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "!python ../local/experiment.py\n"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 2
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython2",
+   "version": "2.7.6"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 0
+}

--- a/src/local/configs/model/random_forest.yaml
+++ b/src/local/configs/model/random_forest.yaml
@@ -1,0 +1,6 @@
+model:
+  name: random_forest
+  params:
+    max_depth: 2
+    min_samples_leaf: 4
+    n_estimators: 2000

--- a/src/local/configs/model/random_forest.yaml
+++ b/src/local/configs/model/random_forest.yaml
@@ -1,6 +1,8 @@
+# @package _global_
+
 model:
   name: random_forest
   params:
-    max_depth: 2
-    min_samples_leaf: 4
-    n_estimators: 2000
+    max_depth: 
+    min_samples_leaf: 1
+    n_estimators: 100

--- a/src/local/configs/rf_compare.yaml
+++ b/src/local/configs/rf_compare.yaml
@@ -13,7 +13,7 @@ phenotype:
 
 data:
   genotype:
-    root: ${split_dir}/genotypes/${node}/fold_${fold_index}
+    root: /media/storage/TG/data/chip/superpop_split/genotypes/${node}/fold_${fold_index}
     train: ${.root}_train
     val: ${.root}_val
     test: ${.root}_test

--- a/src/local/configs/rf_compare.yaml
+++ b/src/local/configs/rf_compare.yaml
@@ -1,0 +1,32 @@
+defaults:
+  - _self_
+  - model: random_forest
+  - experiment: tg
+
+study: tg
+split_dir: /media/storage/TG/data_compare
+node: ALL
+fold_index: 0
+
+phenotype:
+  name: ancestry
+
+data:
+  genotype:
+    root: ${split_dir}/genotypes/${node}/fold_${fold_index}
+    train: ${.root}_train
+    val: ${.root}_val
+    test: ${.root}_test
+
+  x_reduced:
+    root: ${split_dir}/new_data/x_filtered/fold_${fold_index}
+    train: ${.root}_train_projections.csv.eigenvec.sscore
+    val: ${.root}_val_projections.csv.eigenvec.sscore
+    test: ${.root}_test_projections.csv.eigenvec.sscore
+
+  phenotype:
+    name: ancestry
+    root: ${split_dir}/new_data/y_filtered/fold_${fold_index}
+    train: ${.root}_train.tsv
+    val: ${.root}_val.tsv
+    test: ${.root}_test.tsv

--- a/src/local/experiment.py
+++ b/src/local/experiment.py
@@ -1,4 +1,7 @@
 from abc import abstractmethod
+import sys
+
+sys.path.append('..')
 
 import hydra
 import logging
@@ -152,9 +155,9 @@ class RandomForestExperiment(LocalExperiment):
     def train(self):
         self.logger.info("Training")
         autolog()
-        self.y_test = numpy.concatenate((self.y_val, self.y_test, self.y_train), axis=0)
-        self.X_test = numpy.concatenate((self.X_val, self.X_test, self.X_train), axis=0)
-        scores = cross_validate(self.model, self.X_test, self.y_test, cv=10, return_train_score=True)
+        self.y.test = numpy.concatenate((self.y.val, self.y.test, self.y.train), axis=0)
+        self.x.test = numpy.concatenate((self.x.val, self.x.test, self.x.train), axis=0)
+        scores = cross_validate(self.model, self.x.test, self.y.test, cv=10, return_train_score=True)
         print(scores)
         #self.model.fit(self.X_train.values, self.y_train.values)
 
@@ -389,6 +392,7 @@ def local_experiment(cfg: DictConfig):
         assert cfg.model.name in ukb_experiment_dict.keys()
         experiment = ukb_experiment_dict[cfg.model.name](cfg)
     else:
+        print(tg_experiment_dict.keys())
         assert cfg.model.name in tg_experiment_dict.keys()
         experiment = tg_experiment_dict[cfg.model.name](cfg)
 


### PR DESCRIPTION
Walk through [src/JupyterNotebooks/comare_rf.ipynb](https://github.com/genxnetwork/uk-biobank/blob/BAR-142-rf-performance-old-new-model-on-modified-new-data/src/JupyterNotebooks/compare_rf.ipynb) to easily replicate the experiment.
To revert config back to normal change `config_name='rf_compare'`  back to `config_name='tg'` in [this](https://github.com/genxnetwork/uk-biobank/blob/093026f1c331196ee66b1e18ecb620ce648aabd8/src/local/experiment.py#L387) line of code.